### PR TITLE
fix/authentication principal

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/SecurityConfig.kt
@@ -63,7 +63,7 @@ class SecurityConfig {
     ): SecurityFilterChain {
 
         val authorizedHttpMethod = listOf(
-            HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.DELETE
+            HttpMethod.GET, HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.DELETE
         )
         http.addFilterBefore(jwtAuthenticationFilter, AuthorizationFilter::class.java)
         http {
@@ -80,7 +80,6 @@ class SecurityConfig {
                 authorizedHttpMethod.forEach {
                     authorize(it, "/api/v1/**", hasAuthority("USER"))
                 }
-                authorize(HttpMethod.GET, "/api/v1/**", permitAll)
                 authorize(anyRequest, denyAll)
             }
             cors {

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/jwt/JwtAuthenticationFilter.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.toyproject.waffle5gramserver.auth.jwt
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUserService
 import io.jsonwebtoken.JwtException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
@@ -16,7 +17,8 @@ import java.lang.IllegalArgumentException
 @Component
 class JwtAuthenticationFilter(
     private val jwtUtils: JwtUtils,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val instagramUserService: InstagramUserService
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(
@@ -28,8 +30,9 @@ class JwtAuthenticationFilter(
             val token = jwtUtils.getTokenFromRequest(request)
             if (token != null) {
                 val username = jwtUtils.validateAccessToken(token)
+                val instagramUser = instagramUserService.loadUserByUsername(username)
                 SecurityContextHolder.getContext().authentication = UsernamePasswordAuthenticationToken(
-                    username, null, setOf(SimpleGrantedAuthority("ROLE_USER"))
+                    instagramUser, null, setOf(SimpleGrantedAuthority("USER"))
                 )
             }
             filterChain.doFilter(request, response)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/controller/CommentController.kt
@@ -1,0 +1,79 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.controller
+
+import com.wafflestudio.toyproject.waffle5gramserver.comment.service.Comment
+import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentAlreadyLikedException
+import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentException
+import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentNotFoundException
+import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentNotLikedException
+import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentService
+import com.wafflestudio.toyproject.waffle5gramserver.comment.service.UserNotFoundException
+import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class CommentController(
+    private val commentService: CommentService,
+) {
+    @GetMapping("/posts/{postId}/comments")
+    fun getCommentsByPost(
+        @PathVariable("postId") postId: Long,
+        pageable: Pageable,
+    ): ResponseEntity<Page<Comment>> {
+        val comments = commentService.getComments(postId, pageable)
+        return ResponseEntity.ok(comments)
+    }
+
+    @PostMapping("/posts/{postId}/comments")
+    fun createComment(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable("postId") postId: Long,
+        @RequestBody content: String,
+    ): ResponseEntity<Comment> {
+        val comment = commentService.create(postId, content, user.id)
+        return ResponseEntity.status(HttpStatus.CREATED).body(comment)
+    }
+
+    @PutMapping("/comments/{commentId}")
+    fun updateComment(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable("commentId") commentId: Long,
+        @RequestBody content: String,
+    ): ResponseEntity<Comment> {
+        val comment = commentService.patch(commentId, content, user.id)
+        return ResponseEntity.ok(comment)
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    fun deleteComment(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable("commentId") commentId: Long,
+    ): ResponseEntity<Unit> {
+        commentService.delete(commentId, user.id)
+        return ResponseEntity.noContent().build()
+    }
+
+    @ExceptionHandler(CommentException::class)
+    fun handleException(e: CommentException): ResponseEntity<Any> {
+        return when (e) {
+            is CommentNotFoundException -> ResponseEntity.notFound().build()
+            is CommentNotLikedException -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+            is CommentAlreadyLikedException -> ResponseEntity.status(HttpStatus.CONFLICT).build()
+            is UserNotFoundException -> ResponseEntity.notFound().build()
+            else -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentEntity.kt
@@ -10,7 +10,7 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import java.util.Date
+import java.time.LocalDateTime
 
 @Entity(name = "comments")
 class CommentEntity(
@@ -18,9 +18,9 @@ class CommentEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L,
     @Column(nullable = false)
-    val text: String = "",
+    var text: String = "",
     @Column(nullable = false)
-    val createdAt: Date,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     val post: PostEntity,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentLikeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentLikeEntity.kt
@@ -1,0 +1,16 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.repository
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity(name = "comment_likes")
+class CommentLikeEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    val userId: Long = 0L,
+    val commentId: Long = 0L,
+    val createdAt: Long = 0L,
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentLikeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentLikeRepository.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentLikeRepository : JpaRepository<CommentLikeEntity, Long> {
+    fun countByCommentId(commentId: Long): Long
+
+    fun findByCommentIdAndUserId(
+        commentId: Long,
+        userId: Long,
+    ): CommentLikeEntity?
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentRepository.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentRepository : JpaRepository<CommentEntity, Long> {
+    fun findByPostId(
+        postId: Long,
+        pageable: Pageable,
+    ): Page<CommentEntity>
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/Comment.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/Comment.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.service
+
+import java.time.LocalDateTime
+
+data class Comment(
+    val id: Long,
+    val postId: Long,
+    val userId: Long,
+    val username: String,
+    val userProfileImageUrl: String?,
+    val text: String,
+    val createdAt: LocalDateTime,
+    val likeCount: Long,
+//    val replyCount: Int,
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentException.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentException.kt
@@ -1,0 +1,13 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.service
+
+sealed class CommentException : RuntimeException()
+
+class CommentNotFoundException : CommentException()
+
+class CommentNotAuthorizedException : CommentException()
+
+class UserNotFoundException : CommentException()
+
+class CommentAlreadyLikedException : CommentException()
+
+class CommentNotLikedException : CommentException()

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentLikeService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentLikeService.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.service
+
+interface CommentLikeService {
+    fun exists(
+        commentId: Long,
+        userId: Long,
+    ): Boolean
+
+    fun create(
+        commentId: Long,
+        userId: Long,
+    )
+
+    fun delete(
+        commentId: Long,
+        userId: Long,
+    )
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentLikeServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentLikeServiceImpl.kt
@@ -1,0 +1,42 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.service
+
+import com.wafflestudio.toyproject.waffle5gramserver.comment.repository.CommentLikeEntity
+import com.wafflestudio.toyproject.waffle5gramserver.comment.repository.CommentLikeRepository
+import com.wafflestudio.toyproject.waffle5gramserver.comment.repository.CommentRepository
+import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserRepository
+
+class CommentLikeServiceImpl(
+    private val commentLikeRepository: CommentLikeRepository,
+    private val commentRepository: CommentRepository,
+    private val userRepository: UserRepository,
+) : CommentLikeService {
+    override fun exists(
+        commentId: Long,
+        userId: Long,
+    ): Boolean {
+        return commentLikeRepository.findByCommentIdAndUserId(commentId, userId) != null
+    }
+
+    override fun create(
+        commentId: Long,
+        userId: Long,
+    ) {
+        if (commentRepository.findById(commentId).isEmpty) throw CommentNotFoundException()
+        if (userRepository.findById(userId).isEmpty) throw UserNotFoundException()
+        if (exists(commentId, userId)) throw CommentAlreadyLikedException()
+        commentLikeRepository.save(
+            CommentLikeEntity(
+                commentId = commentId,
+                userId = userId,
+            ),
+        )
+    }
+
+    override fun delete(
+        commentId: Long,
+        userId: Long,
+    ) {
+        val like = commentLikeRepository.findByCommentIdAndUserId(commentId, userId) ?: throw CommentNotLikedException()
+        commentLikeRepository.delete(like)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentService.kt
@@ -1,0 +1,28 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.service
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface CommentService {
+    fun getComments(
+        postId: Long,
+        pageable: Pageable,
+    ): Page<Comment>
+
+    fun create(
+        postId: Long,
+        content: String,
+        userId: Long,
+    ): Comment
+
+    fun patch(
+        commentId: Long,
+        content: String,
+        userId: Long,
+    ): Comment
+
+    fun delete(
+        commentId: Long,
+        userId: Long,
+    )
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/service/CommentServiceImpl.kt
@@ -1,0 +1,95 @@
+package com.wafflestudio.toyproject.waffle5gramserver.comment.service
+
+import com.wafflestudio.toyproject.waffle5gramserver.comment.repository.CommentEntity
+import com.wafflestudio.toyproject.waffle5gramserver.comment.repository.CommentLikeRepository
+import com.wafflestudio.toyproject.waffle5gramserver.comment.repository.CommentRepository
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostRepository
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostNotFoundException
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.UserNotFoundException
+import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserRepository
+import jakarta.transaction.Transactional
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class CommentServiceImpl(
+    private val commentRepository: CommentRepository,
+    private val userRepository: UserRepository,
+    private val postRepository: PostRepository,
+    private val commentLikeRepository: CommentLikeRepository,
+) : CommentService {
+    override fun getComments(
+        postId: Long,
+        pageable: Pageable,
+    ): Page<Comment> {
+        val comments = commentRepository.findByPostId(postId, pageable)
+        return comments.map { convertToDTO(it) }
+    }
+
+    @Transactional
+    override fun create(
+        postId: Long,
+        content: String,
+        userId: Long,
+    ): Comment {
+        val user = userRepository.findById(userId).orElseThrow { UserNotFoundException() }
+
+        val post = postRepository.findById(postId).orElseThrow { PostNotFoundException() }
+
+        val comment =
+            CommentEntity(
+                text = content,
+                user = user,
+                post = post,
+                createdAt = LocalDateTime.now(),
+            )
+
+        val entity = commentRepository.save(comment)
+        return convertToDTO(entity)
+    }
+
+    @Transactional
+    override fun patch(
+        commentId: Long,
+        content: String,
+        userId: Long,
+    ): Comment {
+        val comment = commentRepository.findById(commentId).orElseThrow { CommentNotFoundException() }
+
+        if (comment.user.id != userId) {
+            throw CommentNotAuthorizedException()
+        }
+
+        comment.text = content
+        val entity = commentRepository.save(comment)
+        return convertToDTO(entity)
+    }
+
+    @Transactional
+    override fun delete(
+        commentId: Long,
+        userId: Long,
+    ) {
+        val comment = commentRepository.findById(commentId).orElseThrow { CommentNotFoundException() }
+        if (comment.user.id != userId) {
+            throw CommentNotAuthorizedException()
+        }
+        commentRepository.delete(comment)
+    }
+
+    fun convertToDTO(comment: CommentEntity): Comment {
+        val likeCount = commentLikeRepository.countByCommentId(comment.id)
+        return Comment(
+            id = comment.id,
+            postId = comment.post.id,
+            userId = comment.user.id,
+            username = comment.user.username,
+            userProfileImageUrl = comment.user.profileImageUrl,
+            text = comment.text,
+            createdAt = comment.createdAt,
+            likeCount = likeCount,
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/global/error_handling/ErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/global/error_handling/ErrorCode.kt
@@ -17,7 +17,6 @@ enum class ErrorCode(
     HTTP_MESSAGE_NOT_READABLE(400, "G003", "request message body가 없거나 값 타입이 올바르지 않습니다."),
     METHOD_NOT_ALLOWED(405, "G004", "허용되지 않은 HTTP method입니다."),
     HTTP_HEADER_INVALID(400, "G005", "request header가 유효하지 않습니다."),
-    INTERNAL_SERVER_ERROR(500, "G006", "내부 서버 오류입니다."),
     ENTITY_TYPE_INVALID(500, "G007", "올바르지 않은 entity type 입니다."),
     FILE_CONVERT_FAIL(500, "G008", "변환할 수 없는 파일입니다."),
 
@@ -37,4 +36,5 @@ enum class ErrorCode(
     // Alarm Exceptions
 
     // other else
+    // INTERNAL_SERVER_ERROR(500, "G006", "내부 서버 오류입니다."),
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/global/error_handling/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/global/error_handling/GlobalExceptionHandler.kt
@@ -3,7 +3,6 @@ package com.wafflestudio.toyproject.waffle5gramserver.global.error_handling
 import com.wafflestudio.toyproject.waffle5gramserver.global.error_handling.ErrorCode.HTTP_HEADER_INVALID
 import com.wafflestudio.toyproject.waffle5gramserver.global.error_handling.ErrorCode.HTTP_MESSAGE_NOT_READABLE
 import com.wafflestudio.toyproject.waffle5gramserver.global.error_handling.ErrorCode.INPUT_VALUE_INVALID
-import com.wafflestudio.toyproject.waffle5gramserver.global.error_handling.ErrorCode.INTERNAL_SERVER_ERROR
 import com.wafflestudio.toyproject.waffle5gramserver.global.error_handling.ErrorCode.METHOD_NOT_ALLOWED
 import jakarta.validation.ConstraintViolationException
 import org.springframework.http.HttpStatus
@@ -26,12 +25,6 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
-
-    @ExceptionHandler
-    protected fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
-        val response: ErrorResponse = ErrorResponse.of(INTERNAL_SERVER_ERROR)
-        return ResponseEntity<ErrorResponse>(response, HttpStatus.INTERNAL_SERVER_ERROR)
-    } // 정체불명의 모든 내부 서버 오류를 handle
 
     @ExceptionHandler
     protected fun handleBusinessException(e: BusinessException): ResponseEntity<ErrorResponse> {
@@ -98,4 +91,11 @@ class GlobalExceptionHandler {
         val response: ErrorResponse = ErrorResponse.of(INPUT_VALUE_INVALID, e.requestPartName)
         return ResponseEntity<ErrorResponse>(response, BAD_REQUEST)
     } // 파일 업로드를 위해 MultiparFile 사용 시 이미지 업로드에 실패하여 발생하는 오류를 handle
+
+    /* @ExceptionHandler
+    protected fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
+        val response: ErrorResponse = ErrorResponse.of(INTERNAL_SERVER_ERROR)
+        return ResponseEntity<ErrorResponse>(response, HttpStatus.INTERNAL_SERVER_ERROR)
+    } // 정체불명의 모든 내부 서버 오류를 handle
+     */
 }

--- a/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/AuthApi.http
+++ b/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/AuthApi.http
@@ -7,6 +7,16 @@ Content-Type: application/json
 }
 
 ###
+POST http://localhost:8080/api/v1/posts
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDU3MzAzMTZ9.Sj9pXU82SSt71gzGWgb0v76B_YdYhH5ksnWJ8nfpmJ8
+
+{
+  "content": "Here's my latest travel photo!",
+  "files": ["https://example.com/path/to/image.jpg"]
+}
+
+### 로그인 실패
 POST http://localhost:8080/api/v1/auth/login
 Content-Type: application/json
 


### PR DESCRIPTION
## 🔑 Key Changes
- `JwtAuthenticationFilter`에서 `SecurityContext.authentication.principal`에 `username` 대신 `InstagramUser` 객체 저장
- GET 메서드도 모두 user 권한을 요구하도록 수정
## :computer: Test Result (기능 구현인 경우)
- `AuthApi.http` 파일에 `POST /api/v1/posts`를 작성하여 테스트했고, `@AuthenticationPrincipal` 정상 작동하는 것 확인했습니다.
## 🙌 To Reviewers
- `GET /api/v1/feed/timeline`은 아직 메인에 병합되지 않은 것 같아 `POST /api/v1/posts`으로 대신 테스트했습니다. (아마 feed에도 잘 적용될 것 같아요)
