### PR TITLE
Feat/user-feed: User Feed Preview와 User Feed 기능 구현

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/UserFeedController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/UserFeedController.kt
@@ -1,0 +1,61 @@
+package com.wafflestudio.toyproject.waffle5gramserver.feed.controller
+
+import com.wafflestudio.toyproject.waffle5gramserver.feed.service.PostPreview
+import com.wafflestudio.toyproject.waffle5gramserver.feed.service.UserFeedService
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/account/{userId}/feed")
+class UserFeedController(
+    private val userFeedService: UserFeedService,
+) {
+    // 1. 유저의 게시물 미리보기 조회 API
+    @GetMapping("/preview")
+    fun getUserFeedPreview(
+        @PathVariable userId: Long,
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(defaultValue = "12") limit: Int,
+    ): ResponseEntity<List<PostPreview>> {
+        val postPreviews = userFeedService.getUserFeedPreview(userId, cursor, limit)
+        return ResponseEntity.ok(postPreviews)
+    }
+
+    // 2. 특정 게시물의 상세 정보 조회 API
+    @GetMapping("/{postId}")
+    fun getPostDetails(
+        @PathVariable userId: Long,
+        @PathVariable postId: Long,
+    ): ResponseEntity<Any> {
+        val postDetails = userFeedService.getPostDetails(postId)
+        return ResponseEntity.ok(postDetails)
+    }
+
+    // 3. 무한 스크롤을 통한 게시물 조회 API
+    // 위로 스크롤하여 최신 게시물 로드
+    @GetMapping("/newer")
+    fun loadNewerPosts(
+        @PathVariable userId: Long,
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(defaultValue = "10") limit: Int,
+    ): ResponseEntity<List<PostDetail>> {
+        val newerPosts = userFeedService.loadNewerPosts(userId, cursor, limit)
+        return ResponseEntity.ok(newerPosts)
+    }
+
+    // 아래로 스크롤하여 이전 게시물 로드
+    @GetMapping("/older")
+    fun loadOlderPosts(
+        @PathVariable userId: Long,
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(defaultValue = "10") limit: Int,
+    ): ResponseEntity<List<PostDetail>> {
+        val olderPosts = userFeedService.loadOlderPosts(userId, cursor, limit)
+        return ResponseEntity.ok(olderPosts)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/PostPreview.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/PostPreview.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.toyproject.waffle5gramserver.feed.service
+
+data class PostPreview(
+    val id: Long,
+    val thumbnailUrl: String,
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedService.kt
@@ -1,0 +1,25 @@
+package com.wafflestudio.toyproject.waffle5gramserver.feed.service
+
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
+
+interface UserFeedService {
+    fun getUserFeedPreview(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostPreview>
+
+    fun getPostDetails(postId: Long): PostDetail
+
+    fun loadNewerPosts(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostDetail>
+
+    fun loadOlderPosts(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostDetail>
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedServiceImpl.kt
@@ -1,0 +1,60 @@
+package com.wafflestudio.toyproject.waffle5gramserver.feed.service
+
+import com.wafflestudio.toyproject.waffle5gramserver.post.mapper.PostMapper
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostRepository
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostNotFoundException
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+
+@Service
+class UserFeedServiceImpl(
+    private val postRepository: PostRepository,
+) : UserFeedService {
+    override fun getUserFeedPreview(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostPreview> {
+        val pageable = PageRequest.of(0, limit)
+        val posts =
+            if (cursor == null) {
+                postRepository.findLatestPostsByUserId(userId, pageable)
+            } else {
+                postRepository.findPostsByUserIdAndCursor(userId, cursor, pageable)
+            }
+
+        return posts.map { post ->
+            PostPreview(
+                id = post.id,
+                thumbnailUrl = post.medias.firstOrNull()?.mediaUrl ?: "",
+                // 첫 번째 미디어의 URL을 사용
+            )
+        }
+    }
+
+    override fun getPostDetails(postId: Long): PostDetail {
+        val post = postRepository.findById(postId).orElseThrow { PostNotFoundException() }
+        return PostMapper.toPostDetailDTO(post)
+    }
+
+    override fun loadNewerPosts(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostDetail> {
+        val pageable = PageRequest.of(0, limit)
+        val posts = postRepository.findNewerPostsByUserIdAndCursor(userId, cursor, pageable)
+        return posts.map { post -> PostMapper.toPostDetailDTO(post) }
+    }
+
+    override fun loadOlderPosts(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostDetail> {
+        val pageable = PageRequest.of(0, limit)
+        val posts = postRepository.findOlderPostsByUserIdAndCursor(userId, cursor, pageable)
+        return posts.map { post -> PostMapper.toPostDetailDTO(post) }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
@@ -5,7 +5,6 @@ import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostMediaEn
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostBrief
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostMedia
-import java.time.LocalDateTime
 
 class PostMapper {
     companion object {
@@ -38,8 +37,6 @@ class PostMapper {
                 order = media.mediaOrder,
                 url = media.mediaUrl,
                 mediaType = media.mediaType,
-                createdAt = LocalDateTime.now(),
-                updatedAt = LocalDateTime.now()
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.toyproject.waffle5gramserver.post.mapper
 
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostMediaEntity
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostAuthor
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostBrief
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostMedia
@@ -19,7 +20,12 @@ class PostMapper {
         fun toPostDetailDTO(entity: PostEntity): PostDetail {
             return PostDetail(
                 id = entity.id,
-                author = entity.user,
+                author =
+                    PostAuthor(
+                        id = entity.user.id,
+                        username = entity.user.username,
+                        profileImageUrl = entity.user.profileImageUrl ?: "",
+                    ),
                 content = entity.content,
                 media = entity.medias.map { media -> toPostMediaDTO(media) },
                 liked = false,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
@@ -21,11 +21,11 @@ class PostMapper {
             return PostDetail(
                 id = entity.id,
                 author =
-                    PostAuthor(
-                        id = entity.user.id,
-                        username = entity.user.username,
-                        profileImageUrl = entity.user.profileImageUrl ?: "",
-                    ),
+                PostAuthor(
+                    id = entity.user.id,
+                    username = entity.user.username,
+                    profileImageUrl = entity.user.profileImageUrl ?: "",
+                ),
                 content = entity.content,
                 media = entity.medias.map { media -> toPostMediaDTO(media) },
                 liked = false,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
@@ -3,7 +3,43 @@ package com.wafflestudio.toyproject.waffle5gramserver.post.repository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface PostRepository : JpaRepository<PostEntity, Long> {
-    fun findAllByUserIdIsNotOrderByCreatedAtDesc(userId: Long, pageable: Pageable): Page<PostEntity>
+    // 사용자 ID에 따른 포스트 목록 조회 (페이지네이션 지원)
+    fun findByUserId(
+        userId: Long,
+        pageable: Pageable,
+    ): Page<PostEntity>
+
+    // 사용자 ID와 커서 기반으로 게시물 목록 조회
+    @Query("SELECT p FROM posts p WHERE p.user.id = :userId AND p.id < :cursor ORDER BY p.id DESC")
+    fun findPostsByUserIdAndCursor(
+        userId: Long,
+        cursor: Long,
+        pageable: Pageable,
+    ): List<PostEntity>
+
+    // 사용자 ID로 최신 게시물 목록 조회 (초기 로드용)
+    @Query("SELECT p FROM posts p WHERE p.user.id = :userId ORDER BY p.id DESC")
+    fun findLatestPostsByUserId(
+        userId: Long,
+        pageable: Pageable,
+    ): List<PostEntity>
+
+    // 커서보다 ID가 큰 게시물 조회 (최신 게시물 로드)
+    @Query("SELECT p FROM posts p WHERE p.user.id = :userId AND (:cursor IS NULL OR p.id > :cursor) ORDER BY p.id ASC")
+    fun findNewerPostsByUserIdAndCursor(
+        userId: Long,
+        cursor: Long?,
+        pageable: Pageable,
+    ): List<PostEntity>
+
+    // 커서보다 ID가 작은 게시물 조회 (이전 게시물 로드)
+    @Query("SELECT p FROM posts p WHERE p.user.id = :userId AND (:cursor IS NULL OR p.id < :cursor) ORDER BY p.id DESC")
+    fun findOlderPostsByUserIdAndCursor(
+        userId: Long,
+        cursor: Long?,
+        pageable: Pageable,
+    ): List<PostEntity>
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostAuthor.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostAuthor.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.toyproject.waffle5gramserver.post.service
+
+data class PostAuthor(
+    val id: Long,
+    val username: String,
+    val profileImageUrl: String,
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostDetail.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostDetail.kt
@@ -1,11 +1,10 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.service
 
-import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserEntity
 import java.time.LocalDateTime
 
 data class PostDetail(
     val id: Long,
-    val author: UserEntity,
+    val author: PostAuthor,
     val content: String,
     val media: List<PostMedia>,
     val liked: Boolean,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostMedia.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostMedia.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.service
 
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.MediaType
-import java.time.LocalDateTime
 
 data class PostMedia(
     val id: Long,
@@ -9,6 +8,4 @@ data class PostMedia(
     val order: Int,
     val url: String,
     val mediaType: MediaType,
-    val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime,
 )


### PR DESCRIPTION
## 🔑 Key Changes
- 사용자의 게시물 미리보기 조회 API 구현
- 특정 게시물의 상세 정보 조회 API 구현
- 특정 게시물의 상세 정보 조회 API 구현
- 무한 스크롤을 통한 이전 게시물 조회 API 구현
## 🙌 To Reviewers
- API를 구현하면서 기존에 지원님이 작성하셨던 reponse와 endpoint에 변화가 생겼습니다! 읽어보시고 의견 부탁드립니다!
## ScreenShot (optional)