### PR TITLE
Feat/post-save: 게시물 저장, 저장 취소 및 저장 여부 확인 API 구현

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/UserFeedController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/UserFeedController.kt
@@ -26,16 +26,6 @@ class UserFeedController(
         return ResponseEntity.ok(postPreviews)
     }
 
-    // 2. 특정 게시물의 상세 정보 조회 API
-    @GetMapping("/{postId}")
-    fun getPostDetails(
-        @PathVariable userId: Long,
-        @PathVariable postId: Long,
-    ): ResponseEntity<Any> {
-        val postDetails = userFeedService.getPostDetails(postId)
-        return ResponseEntity.ok(postDetails)
-    }
-
     // 3. 무한 스크롤을 통한 게시물 조회 API
     // 위로 스크롤하여 최신 게시물 로드
     @GetMapping("/newer")

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedService.kt
@@ -9,8 +9,6 @@ interface UserFeedService {
         limit: Int,
     ): List<PostPreview>
 
-    fun getPostDetails(postId: Long): PostDetail
-
     fun loadNewerPosts(
         userId: Long,
         cursor: Long?,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/controller/PostController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/controller/PostController.kt
@@ -1,6 +1,18 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.controller
 
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.*
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostAlreadyLikedException
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostAlreadySavedException
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostBrief
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostException
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostLikeService
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostNotAuthorizedException
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostNotFoundException
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostNotLikedException
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostNotSavedException
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostSaveService
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostService
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.UserNotFoundException
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/controller/PostController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/controller/PostController.kt
@@ -1,14 +1,6 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.controller
 
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostAlreadyLikedException
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostBrief
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostException
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostNotAuthorizedException
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostNotFoundException
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostNotLikedException
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostService
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.UserNotFoundException
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.*
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -27,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1")
 class PostController(
     private val postService: PostService,
+    private val postLikeService: PostLikeService,
+    private val postSaveService: PostSaveService,
 ) {
     @PostMapping("/posts")
     fun createPost(
@@ -79,14 +73,52 @@ class PostController(
         return ResponseEntity.ok(updatedPost)
     }
 
+    @PostMapping("/posts/{postId}/likes")
+    fun createPostLike(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable postId: Long,
+    ): ResponseEntity<Unit> {
+        postLikeService.create(postId, user.id)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @DeleteMapping("/posts/{postId}/likes")
+    fun deletePostLike(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable postId: Long,
+    ): ResponseEntity<Unit> {
+        postLikeService.delete(postId, user.id)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/posts/{postId}/saves")
+    fun createPostSave(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable postId: Long,
+    ): ResponseEntity<Unit> {
+        postSaveService.create(postId, user.id)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @DeleteMapping("/posts/{postId}/saves")
+    fun deletePostSave(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable postId: Long,
+    ): ResponseEntity<Unit> {
+        postSaveService.delete(postId, user.id)
+        return ResponseEntity.noContent().build()
+    }
+
     @ExceptionHandler(PostException::class)
     fun handleException(e: PostException): ResponseEntity<Any> {
         return when (e) {
             is PostNotFoundException -> ResponseEntity.notFound().build()
             is PostNotAuthorizedException -> ResponseEntity.status(403).build()
             is UserNotFoundException -> ResponseEntity.status(404).build()
-            is PostAlreadyLikedException, is PostNotLikedException -> ResponseEntity.status(409).build()
-            else -> ResponseEntity.status(500).build()
+            is PostAlreadyLikedException, is PostNotLikedException, is PostAlreadySavedException, is PostNotSavedException ->
+                ResponseEntity.status(
+                    409,
+                ).build()
         }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
@@ -1,7 +1,9 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.mapper
 
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostLikeEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostMediaEntity
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostSaveEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostAuthor
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostBrief
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
@@ -17,7 +19,11 @@ class PostMapper {
             )
         }
 
-        fun toPostDetailDTO(entity: PostEntity): PostDetail {
+        fun toPostDetailDTO(
+            entity: PostEntity,
+            postLike: PostLikeEntity?,
+            postSave: PostSaveEntity?,
+        ): PostDetail {
             return PostDetail(
                 id = entity.id,
                 author =
@@ -28,8 +34,9 @@ class PostMapper {
                 ),
                 content = entity.content,
                 media = entity.medias.map { media -> toPostMediaDTO(media) },
-                liked = false,
-                likeCount = 0,
+                liked = postLike != null,
+                likeCount = entity.likeCount,
+                saved = postSave != null,
                 commentCount = entity.comments.size,
                 hideLike = entity.likeCountDisplayed,
                 createdAt = entity.createdAt,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
@@ -1,9 +1,7 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.mapper
 
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
-import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostLikeEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostMediaEntity
-import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostSaveEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostAuthor
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostBrief
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
@@ -21,22 +19,22 @@ class PostMapper {
 
         fun toPostDetailDTO(
             entity: PostEntity,
-            postLike: PostLikeEntity?,
-            postSave: PostSaveEntity?,
+            isLiked: Boolean,
+            isSaved: Boolean,
         ): PostDetail {
             return PostDetail(
                 id = entity.id,
                 author =
-                PostAuthor(
-                    id = entity.user.id,
-                    username = entity.user.username,
-                    profileImageUrl = entity.user.profileImageUrl ?: "",
-                ),
+                    PostAuthor(
+                        id = entity.user.id,
+                        username = entity.user.username,
+                        profileImageUrl = entity.user.profileImageUrl ?: "",
+                    ),
                 content = entity.content,
                 media = entity.medias.map { media -> toPostMediaDTO(media) },
-                liked = postLike != null,
+                liked = isLiked,
                 likeCount = entity.likeCount,
-                saved = postSave != null,
+                saved = isSaved,
                 commentCount = entity.comments.size,
                 hideLike = entity.likeCountDisplayed,
                 createdAt = entity.createdAt,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
@@ -25,11 +25,11 @@ class PostMapper {
             return PostDetail(
                 id = entity.id,
                 author =
-                    PostAuthor(
-                        id = entity.user.id,
-                        username = entity.user.username,
-                        profileImageUrl = entity.user.profileImageUrl ?: "",
-                    ),
+                PostAuthor(
+                    id = entity.user.id,
+                    username = entity.user.username,
+                    profileImageUrl = entity.user.profileImageUrl ?: "",
+                ),
                 content = entity.content,
                 media = entity.medias.map { media -> toPostMediaDTO(media) },
                 liked = isLiked,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostEntity.kt
@@ -23,6 +23,8 @@ class PostEntity(
     var id: Long = 0L,
     @Column(name = "content", nullable = false)
     var content: String = "",
+    @Column(name = "like_count", nullable = false)
+    var likeCount: Int = 0,
     @Column(name = "like_count_displayed", nullable = false)
     var likeCountDisplayed: Boolean = true,
     @Column(name = "comment_displayed", nullable = false)
@@ -43,5 +45,13 @@ class PostEntity(
 ) {
     fun addMedia(media: PostMediaEntity) {
         medias.add(media)
+    }
+
+    fun incrementLikeCount() {
+        likeCount += 1
+    }
+
+    fun decrementLikeCount() {
+        likeCount -= 1
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostLikeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostLikeRepository.kt
@@ -8,7 +8,5 @@ interface PostLikeRepository : JpaRepository<PostLikeEntity, Long> {
         userId: Long,
     ): PostLikeEntity?
 
-    fun countByPostId(postId: Long): Long
-
     fun deleteAllByPostId(postId: Long)
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveEntity.kt
@@ -10,7 +10,7 @@ class PostSaveEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L,
-    var userId: Long = 0L,
-    var postId: Long = 0L,
+    val userId: Long = 0L,
+    val postId: Long = 0L,
     val createdAt: Long = 0L,
 )

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveEntity.kt
@@ -1,0 +1,16 @@
+package com.wafflestudio.toyproject.waffle5gramserver.post.repository
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity(name = "post_saves")
+class PostSaveEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L,
+    var userId: Long = 0L,
+    var postId: Long = 0L,
+    val createdAt: Long = 0L,
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
@@ -7,4 +7,6 @@ interface PostSaveRepository : JpaRepository<PostSaveEntity, Long> {
         userId: Long,
         postId: Long,
     ): PostSaveEntity?
+
+    fun deleteAllbyPostId(postId: Long)
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
@@ -9,4 +9,9 @@ interface PostSaveRepository : JpaRepository<PostSaveEntity, Long> {
     ): PostSaveEntity?
 
     fun deleteAllByPostId(postId: Long)
+
+    fun findByPostIdAndUserId(
+        postId: Long,
+        userId: Long,
+    ): PostSaveEntity?
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
@@ -8,5 +8,5 @@ interface PostSaveRepository : JpaRepository<PostSaveEntity, Long> {
         postId: Long,
     ): PostSaveEntity?
 
-    fun deleteAllbyPostId(postId: Long)
+    fun deleteAllByPostId(postId: Long)
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.toyproject.waffle5gramserver.post.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PostSaveRepository : JpaRepository<PostSaveEntity, Long> {
+    fun findByUserIdAndPostId(
+        userId: Long,
+        postId: Long,
+    ): PostSaveEntity?
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostDetail.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostDetail.kt
@@ -9,6 +9,7 @@ data class PostDetail(
     val media: List<PostMedia>,
     val liked: Boolean,
     val likeCount: Int,
+    val saved: Boolean,
     val commentCount: Int,
     val hideLike: Boolean,
     val createdAt: LocalDateTime,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostException.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostException.kt
@@ -10,4 +10,8 @@ class PostAlreadyLikedException : PostException()
 
 class PostNotLikedException : PostException()
 
+class PostAlreadySavedException : PostException()
+
+class PostNotSavedException : PostException()
+
 class UserNotFoundException : PostException()

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostLikeServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostLikeServiceImpl.kt
@@ -25,10 +25,13 @@ class PostLikeServiceImpl(
         postId: Long,
         userId: Long,
     ) {
-        if (postRepository.findById(postId).isEmpty) throw PostNotFoundException()
+        val post = postRepository.findById(postId).orElseThrow { PostNotFoundException() }
         if (userRepository.findById(userId).isEmpty) throw UserNotFoundException()
 
         if (exists(postId, userId)) throw PostAlreadyLikedException()
+
+        post.incrementLikeCount()
+        postRepository.save(post)
 
         postLikeRepository.save(
             PostLikeEntity(
@@ -43,7 +46,12 @@ class PostLikeServiceImpl(
         postId: Long,
         userId: Long,
     ) {
+        val post = postRepository.findById(postId).orElseThrow { PostNotFoundException() }
         val like = postLikeRepository.findByPostIdAndUserId(postId, userId) ?: throw PostNotLikedException()
+
+        post.decrementLikeCount()
+        postRepository.save(post)
+
         postLikeRepository.delete(like)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostSaveService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostSaveService.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.toyproject.waffle5gramserver.post.service
+
+interface PostSaveService {
+    fun exists(
+        postId: Long,
+        userId: Long,
+    ): Boolean
+
+    fun create(
+        postId: Long,
+        userId: Long,
+    )
+
+    fun delete(
+        postId: Long,
+        userId: Long,
+    )
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostSaveServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostSaveServiceImpl.kt
@@ -1,0 +1,45 @@
+package com.wafflestudio.toyproject.waffle5gramserver.post.service
+
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostSaveEntity
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostSaveRepository
+import org.springframework.stereotype.Service
+
+@Service
+class PostSaveServiceImpl(
+    private val postSaveRepository: PostSaveRepository,
+) : PostSaveService {
+    override fun exists(
+        postId: Long,
+        userId: Long,
+    ): Boolean {
+        return postSaveRepository.findByUserIdAndPostId(userId, postId) != null
+    }
+
+    override fun create(
+        postId: Long,
+        userId: Long,
+    ) {
+        val existingSave = postSaveRepository.findByUserIdAndPostId(userId, postId)
+        if (existingSave != null) {
+            throw PostAlreadySavedException()
+        }
+
+        val newSave =
+            PostSaveEntity(
+                userId = userId,
+                postId = postId,
+                createdAt = System.currentTimeMillis(),
+            )
+
+        postSaveRepository.save(newSave)
+    }
+
+    override fun delete(
+        postId: Long,
+        userId: Long,
+    ) {
+        val existingSave = postSaveRepository.findByUserIdAndPostId(userId, postId) ?: throw PostNotSavedException()
+
+        postSaveRepository.delete(existingSave)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostServiceImpl.kt
@@ -22,7 +22,10 @@ class PostServiceImpl(
         postId: Long,
         userId: Long,
     ): PostDetail {
-        TODO()
+        val post = postRepository.findById(postId).orElseThrow { PostNotFoundException() }
+        val postLike = postLikeRepository.findByPostIdAndUserId(postId, userId)
+        val postSave = postSaveRepository.findByPostIdAndUserId(postId, userId)
+        return PostMapper.toPostDetailDTO(post, postLike, postSave)
     }
 
     @Transactional

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostServiceImpl.kt
@@ -83,7 +83,7 @@ class PostServiceImpl(
             throw PostNotAuthorizedException()
         }
         postLikeRepository.deleteAllByPostId(postId)
-        postSaveRepository.deleteAllbyPostId(postId)
+        postSaveRepository.deleteAllByPostId(postId)
         postRepository.delete(post)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostServiceImpl.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostLikeRepository
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostMediaEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostRepository
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostSaveRepository
 import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -15,6 +16,7 @@ class PostServiceImpl(
     private val postRepository: PostRepository,
     private val userRepository: UserRepository,
     private val postLikeRepository: PostLikeRepository,
+    private val postSaveRepository: PostSaveRepository,
 ) : PostService {
     override fun get(
         postId: Long,
@@ -81,6 +83,7 @@ class PostServiceImpl(
             throw PostNotAuthorizedException()
         }
         postLikeRepository.deleteAllByPostId(postId)
+        postSaveRepository.deleteAllbyPostId(postId)
         postRepository.delete(post)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostServiceImpl.kt
@@ -23,9 +23,9 @@ class PostServiceImpl(
         userId: Long,
     ): PostDetail {
         val post = postRepository.findById(postId).orElseThrow { PostNotFoundException() }
-        val postLike = postLikeRepository.findByPostIdAndUserId(postId, userId)
-        val postSave = postSaveRepository.findByPostIdAndUserId(postId, userId)
-        return PostMapper.toPostDetailDTO(post, postLike, postSave)
+        val isLiked = postLikeRepository.findByPostIdAndUserId(postId, userId) != null
+        val isSaved = postSaveRepository.findByPostIdAndUserId(postId, userId) != null
+        return PostMapper.toPostDetailDTO(post, isLiked, isSaved)
     }
 
     @Transactional


### PR DESCRIPTION
## 🔑 Key Changes
- 기존의 like 구현과 동일한 방식으로 service를 구성하였습니다.
- PostDetails DTO에 like, save 필드를 정상적으로 내려주도록 수정했습니다.
- 상세 포스트 불러오기의 경우 기존 postService의 get 메소드가 담당하도록 위치를 수정하였습니다. ( API 명세 역시 수정하였습니다! )
## 🙌 To Reviewers
- like 구현과 마찬가지로 중계테이블이지만, Manytoone으로 연결할 시 불필요한 쿼리가 날아갈 것으로 예상되어 매핑을 진행하지 않았습니다.
- 이에 post, user 삭제 시 연결되는 like, save 삭제하는 코드를 서비스에 추가하였습니다.
## ScreenShot (optional)