### PR TITLE
feat: 저장된 게시물 미리보기, 스크롤 API 구현

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/SavedFeedController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/SavedFeedController.kt
@@ -1,0 +1,47 @@
+package com.wafflestudio.toyproject.waffle5gramserver.feed.controller
+
+import com.wafflestudio.toyproject.waffle5gramserver.feed.service.PostPreview
+import com.wafflestudio.toyproject.waffle5gramserver.feed.service.SavedFeedService
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/account/{userId}/saved-feed")
+class SavedFeedController(
+    private val savedFeedService: SavedFeedService,
+) {
+    @GetMapping("/preview")
+    fun getSavedFeedPreview(
+        @PathVariable userId: Long,
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(defaultValue = "12") limit: Int,
+    ): ResponseEntity<List<PostPreview>> {
+        val postPreviews = savedFeedService.getSavedFeedPreview(userId, cursor, limit)
+        return ResponseEntity.ok(postPreviews)
+    }
+
+    @GetMapping("/newer")
+    fun loadNewerPosts(
+        @PathVariable userId: Long,
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(defaultValue = "10") limit: Int,
+    ): ResponseEntity<List<PostDetail>> {
+        val newerPosts = savedFeedService.loadNewerPosts(userId, cursor, limit)
+        return ResponseEntity.ok(newerPosts)
+    }
+
+    @GetMapping("/older")
+    fun loadOlderPosts(
+        @PathVariable userId: Long,
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(defaultValue = "10") limit: Int,
+    ): ResponseEntity<List<PostDetail>> {
+        val olderPosts = savedFeedService.loadOlderPosts(userId, cursor, limit)
+        return ResponseEntity.ok(olderPosts)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/SavedFeedService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/SavedFeedService.kt
@@ -1,0 +1,23 @@
+package com.wafflestudio.toyproject.waffle5gramserver.feed.service
+
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
+
+interface SavedFeedService {
+    fun getSavedFeedPreview(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostPreview>
+
+    fun loadNewerPosts(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostDetail>
+
+    fun loadOlderPosts(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostDetail>
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/SavedFeedServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/SavedFeedServiceImpl.kt
@@ -1,0 +1,66 @@
+package com.wafflestudio.toyproject.waffle5gramserver.feed.service
+
+import com.wafflestudio.toyproject.waffle5gramserver.post.mapper.PostMapper
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostLikeRepository
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostRepository
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostSaveRepository
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+
+@Service
+class SavedFeedServiceImpl(
+    private val postRepository: PostRepository,
+    private val postLikeRepository: PostLikeRepository,
+    private val postSaveRepository: PostSaveRepository,
+) : SavedFeedService {
+    override fun getSavedFeedPreview(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostPreview> {
+        val pageable = PageRequest.of(0, limit)
+        val posts =
+            if (cursor == null) {
+                postRepository.findLatestPostsByUserId(userId, pageable)
+            } else {
+                postRepository.findPostsByUserIdAndCursor(userId, cursor, pageable)
+            }
+
+        return posts.map { post ->
+            PostPreview(
+                id = post.id,
+                thumbnailUrl = post.medias.firstOrNull()?.mediaUrl ?: "",
+                // 첫 번째 미디어의 URL을 사용
+            )
+        }
+    }
+
+    override fun loadNewerPosts(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostDetail> {
+        val pageable = PageRequest.of(0, limit)
+        val posts = postRepository.findNewerPostsByUserIdAndCursor(userId, cursor, pageable)
+        return posts.map { post ->
+            val isLiked = postLikeRepository.findByPostIdAndUserId(post.id, userId) != null
+            val isSaved = postSaveRepository.findByPostIdAndUserId(post.id, userId) != null
+            PostMapper.toPostDetailDTO(post, isLiked, isSaved)
+        }
+    }
+
+    override fun loadOlderPosts(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<PostDetail> {
+        val pageable = PageRequest.of(0, limit)
+        val posts = postRepository.findOlderPostsByUserIdAndCursor(userId, cursor, pageable)
+        return posts.map { post ->
+            val isLiked = postLikeRepository.findByPostIdAndUserId(post.id, userId) != null
+            val isSaved = postSaveRepository.findByPostIdAndUserId(post.id, userId) != null
+            PostMapper.toPostDetailDTO(post, isLiked, isSaved)
+        }
+    }
+}


### PR DESCRIPTION
## 🔑 Key Changes
- 저장된 게시물 미리보기, 스크롤 API 구현입니다.
## 🙌 To Reviewers
- 기존 UserFeed와 구조가 같아 해당 PR시 리뷰를 반영하여 바로 머지하겠습니다.
## ScreenShot (optional)