### PR TITLE
Fix/add-comment-like-endpoint: reply, comment에 like 관련 endpoint 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/controller/CommentController.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.toyproject.waffle5gramserver.comment.controller
 import com.wafflestudio.toyproject.waffle5gramserver.comment.service.Comment
 import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentAlreadyLikedException
 import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentException
+import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentLikeService
 import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentNotFoundException
 import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentNotLikedException
 import com.wafflestudio.toyproject.waffle5gramserver.comment.service.CommentService
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1")
 class CommentController(
     private val commentService: CommentService,
+    private val commentLikeService: CommentLikeService,
 ) {
     @GetMapping("/posts/{postId}/comments")
     fun getCommentsByPost(
@@ -64,6 +66,24 @@ class CommentController(
         @PathVariable("commentId") commentId: Long,
     ): ResponseEntity<Unit> {
         commentService.delete(commentId, user.id)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/comments/{commentId}/likes")
+    fun createCommentLike(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable commentId: Long,
+    ): ResponseEntity<Unit> {
+        commentLikeService.create(commentId, user.id)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @DeleteMapping("/comments/{commentId}/likes")
+    fun deleteCommentLike(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable commentId: Long,
+    ): ResponseEntity<Unit> {
+        commentLikeService.delete(commentId, user.id)
         return ResponseEntity.noContent().build()
     }
 

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/comment/repository/CommentEntity.kt
@@ -20,6 +20,8 @@ class CommentEntity(
     @Column(nullable = false)
     var text: String = "",
     @Column(nullable = false)
+    var likeCount: Int = 0,
+    @Column(nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
@@ -27,4 +29,12 @@ class CommentEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     val user: UserEntity,
-)
+) {
+    fun incrementLikeCount() {
+        likeCount += 1
+    }
+
+    fun decrementLikeCount() {
+        likeCount -= 1
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostSaveServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostSaveServiceImpl.kt
@@ -1,12 +1,15 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.service
 
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostRepository
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostSaveEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostSaveRepository
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
 @Service
 class PostSaveServiceImpl(
     private val postSaveRepository: PostSaveRepository,
+    private val postRepository: PostRepository,
 ) : PostSaveService {
     override fun exists(
         postId: Long,
@@ -15,29 +18,29 @@ class PostSaveServiceImpl(
         return postSaveRepository.findByUserIdAndPostId(userId, postId) != null
     }
 
+    @Transactional
     override fun create(
         postId: Long,
         userId: Long,
     ) {
-        val existingSave = postSaveRepository.findByUserIdAndPostId(userId, postId)
-        if (existingSave != null) {
-            throw PostAlreadySavedException()
-        }
+        val post = postRepository.findById(postId).orElseThrow { PostNotFoundException() }
 
-        val newSave =
+        if (exists(postId, userId)) throw PostAlreadySavedException()
+
+        postSaveRepository.save(
             PostSaveEntity(
-                userId = userId,
                 postId = postId,
-                createdAt = System.currentTimeMillis(),
-            )
-
-        postSaveRepository.save(newSave)
+                userId = userId,
+            ),
+        )
     }
 
+    @Transactional
     override fun delete(
         postId: Long,
         userId: Long,
     ) {
+        val post = postRepository.findById(postId).orElseThrow { PostNotFoundException() }
         val existingSave = postSaveRepository.findByUserIdAndPostId(userId, postId) ?: throw PostNotSavedException()
 
         postSaveRepository.delete(existingSave)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/controller/ReplyController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/controller/ReplyController.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.toyproject.waffle5gramserver.reply.controller
 import com.wafflestudio.toyproject.waffle5gramserver.reply.service.Reply
 import com.wafflestudio.toyproject.waffle5gramserver.reply.service.ReplyAlreadyLikedException
 import com.wafflestudio.toyproject.waffle5gramserver.reply.service.ReplyException
+import com.wafflestudio.toyproject.waffle5gramserver.reply.service.ReplyLikeService
 import com.wafflestudio.toyproject.waffle5gramserver.reply.service.ReplyNotAuthorizedException
 import com.wafflestudio.toyproject.waffle5gramserver.reply.service.ReplyNotFoundException
 import com.wafflestudio.toyproject.waffle5gramserver.reply.service.ReplyNotLikedException
@@ -28,13 +29,15 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1")
 class ReplyController(
     private val replyService: ReplyService,
+    private val replyLikeService: ReplyLikeService,
 ) {
     @GetMapping("/comments/{commentId}/replies")
     fun getReplies(
         @PathVariable("commentId") commentId: Long,
         pageable: Pageable,
+        @AuthenticationPrincipal user: InstagramUser,
     ): ResponseEntity<Page<Reply>> {
-        val replies = replyService.getReplies(commentId, pageable)
+        val replies = replyService.getReplies(commentId, pageable, userId = user.id)
         return ResponseEntity.ok(replies)
     }
 
@@ -64,6 +67,24 @@ class ReplyController(
         @PathVariable("replyId") replyId: Long,
     ): ResponseEntity<Unit> {
         replyService.delete(replyId, user.id)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/replies/{replyId}/likes")
+    fun createReplyLike(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable("replyId") replyId: Long,
+    ): ResponseEntity<Unit> {
+        replyLikeService.create(replyId, user.id)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @DeleteMapping("/replies/{replyId}/likes")
+    fun unlikeReply(
+        @AuthenticationPrincipal user: InstagramUser,
+        @PathVariable("replyId") replyId: Long,
+    ): ResponseEntity<Unit> {
+        replyLikeService.delete(replyId, user.id)
         return ResponseEntity.noContent().build()
     }
 

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/repository/ReplyEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/repository/ReplyEntity.kt
@@ -20,6 +20,8 @@ class ReplyEntity(
     @Column(columnDefinition = "LONGTEXT")
     var content: String,
     @Column(nullable = false)
+    var likeCount: Int = 0,
+    @Column(nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -27,4 +29,12 @@ class ReplyEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id", nullable = false)
     val comment: CommentEntity,
-)
+) {
+    fun incrementLikeCount() {
+        likeCount += 1
+    }
+
+    fun decrementLikeCount() {
+        likeCount -= 1
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/Reply.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/Reply.kt
@@ -11,4 +11,5 @@ data class Reply(
     val content: String,
     val likeCount: Long,
     val createdAt: LocalDateTime,
+    val liked: Boolean,
 )

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/ReplyLikeServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/ReplyLikeServiceImpl.kt
@@ -4,7 +4,9 @@ import com.wafflestudio.toyproject.waffle5gramserver.reply.repository.ReplyLikeE
 import com.wafflestudio.toyproject.waffle5gramserver.reply.repository.ReplyLikeRepository
 import com.wafflestudio.toyproject.waffle5gramserver.reply.repository.ReplyRepository
 import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserRepository
+import org.springframework.stereotype.Service
 
+@Service
 class ReplyLikeServiceImpl(
     private val replyLikeRepository: ReplyLikeRepository,
     private val replyRepository: ReplyRepository,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/ReplyLikeServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/ReplyLikeServiceImpl.kt
@@ -4,6 +4,7 @@ import com.wafflestudio.toyproject.waffle5gramserver.reply.repository.ReplyLikeE
 import com.wafflestudio.toyproject.waffle5gramserver.reply.repository.ReplyLikeRepository
 import com.wafflestudio.toyproject.waffle5gramserver.reply.repository.ReplyRepository
 import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserRepository
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
 @Service
@@ -19,13 +20,19 @@ class ReplyLikeServiceImpl(
         return replyLikeRepository.findByReplyIdAndUserId(replyId, userId) != null
     }
 
+    @Transactional
     override fun create(
         replyId: Long,
         userId: Long,
     ) {
-        if (replyRepository.findById(replyId).isEmpty) throw ReplyNotFoundException()
+        val reply = replyRepository.findById(replyId).orElseThrow { ReplyNotFoundException() }
         if (userRepository.findById(userId).isEmpty) throw UserNotFoundException()
+
         if (exists(replyId, userId)) throw ReplyAlreadyLikedException()
+
+        reply.incrementLikeCount()
+        replyRepository.save(reply)
+
         replyLikeRepository.save(
             ReplyLikeEntity(
                 replyId = replyId,
@@ -34,11 +41,17 @@ class ReplyLikeServiceImpl(
         )
     }
 
+    @Transactional
     override fun delete(
         replyId: Long,
         userId: Long,
     ) {
+        val reply = replyRepository.findById(replyId).orElseThrow { ReplyNotFoundException() }
         val like = replyLikeRepository.findByReplyIdAndUserId(replyId, userId) ?: throw ReplyNotLikedException()
+
+        reply.decrementLikeCount()
+        replyRepository.save(reply)
+
         replyLikeRepository.delete(like)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/ReplyService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/ReplyService.kt
@@ -7,6 +7,7 @@ interface ReplyService {
     fun getReplies(
         commentId: Long,
         pageable: Pageable,
+        userId: Long,
     ): Page<Reply>
 
     fun create(

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/ReplyServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/reply/service/ReplyServiceImpl.kt
@@ -21,9 +21,10 @@ class ReplyServiceImpl(
     override fun getReplies(
         commentId: Long,
         pageable: Pageable,
+        userId: Long,
     ): Page<Reply> {
         val replies = replyRepository.findByCommentId(commentId, pageable)
-        return replies.map { convertToDTO(it) }
+        return replies.map { convertToDTO(it, userId) }
     }
 
     @Transactional
@@ -44,7 +45,7 @@ class ReplyServiceImpl(
             )
 
         val entity = replyRepository.save(reply)
-        return convertToDTO(entity)
+        return convertToDTO(entity, userId)
     }
 
     @Transactional
@@ -61,7 +62,7 @@ class ReplyServiceImpl(
 
         reply.content = content
         val entity = replyRepository.save(reply)
-        return convertToDTO(entity)
+        return convertToDTO(entity, userId)
     }
 
     @Transactional
@@ -76,8 +77,12 @@ class ReplyServiceImpl(
         replyRepository.delete(reply)
     }
 
-    fun convertToDTO(reply: ReplyEntity): Reply {
+    fun convertToDTO(
+        reply: ReplyEntity,
+        userId: Long,
+    ): Reply {
         val likeCount = replyLikeRepository.countByReplyId(reply.id)
+        val isLiked = replyLikeRepository.findByReplyIdAndUserId(reply.id, userId) != null
         return Reply(
             id = reply.id,
             commentId = reply.comment.id,
@@ -87,6 +92,7 @@ class ReplyServiceImpl(
             content = reply.content,
             createdAt = reply.createdAt,
             likeCount = likeCount,
+            liked = isLiked,
         )
     }
 }


### PR DESCRIPTION
## 🔑 Key Changes
- comment, reply controller에 like 관련 endpoint를 추가했습니다.
- 누락되어 있던 Transactional 어노테이션을 추가했습니다.
- Entity에 likecount 필드를 추가하였습니다.
## ScreenShot (optional)