### PR TITLE
fix: refresh token을 request body로 받도록 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/controller/FacebookSignUpController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/controller/FacebookSignUpController.kt
@@ -24,7 +24,7 @@ class FacebookSignUpController(
         request: HttpServletRequest,
         response: HttpServletResponse
     ): ResponseEntity<AccessTokenResponseDto> {
-        val refreshToken = tokenRefreshService.extractRefreshToken(request)
+        val refreshToken = facebookSignUpRequestDto.refreshToken
         val temporaryUsername = tokenRefreshService.validateRefreshToken(refreshToken)
         val newUsername = customOAuth2UserService.updateFacebookOAuth2User(
             temporaryUsername = temporaryUsername,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/controller/RefreshTokenController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/controller/RefreshTokenController.kt
@@ -1,12 +1,13 @@
 package com.wafflestudio.toyproject.waffle5gramserver.auth.controller
 
 import com.wafflestudio.toyproject.waffle5gramserver.auth.dto.AccessTokenResponseDto
+import com.wafflestudio.toyproject.waffle5gramserver.auth.dto.RefreshTokenDto
 import com.wafflestudio.toyproject.waffle5gramserver.auth.service.TokenRefreshService
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -15,10 +16,10 @@ class RefreshTokenController(
 ) {
     @GetMapping("/api/v1/auth/refresh_token")
     fun refreshToken(
-        request: HttpServletRequest,
+        @RequestBody refreshTokenDto: RefreshTokenDto,
         response: HttpServletResponse
     ): ResponseEntity<AccessTokenResponseDto> {
-        val refreshToken = tokenRefreshService.extractRefreshToken(request)
+        val refreshToken = refreshTokenDto.refreshToken
         val username = tokenRefreshService.validateRefreshToken(refreshToken)
         val newAccessToken = tokenRefreshService.generateNewAccessToken(username)
         val newRefreshToken = tokenRefreshService.generateNewRefreshToken(username)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/dto/FacebookSignUpRequestDto.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/dto/FacebookSignUpRequestDto.kt
@@ -7,5 +7,7 @@ class FacebookSignUpRequestDto(
     @NotBlank
     val username: String,
     @NotBlank
-    val birthday: Date
+    val birthday: Date,
+    @NotBlank
+    val refreshToken: String,
 )

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/dto/RefreshTokenDto.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/dto/RefreshTokenDto.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.toyproject.waffle5gramserver.auth.dto
+
+data class RefreshTokenDto(
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/service/TokenRefreshService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/service/TokenRefreshService.kt
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 
 interface TokenRefreshService {
-    fun extractRefreshToken(request: HttpServletRequest): String
+    fun extractRefreshTokenFromCookie(request: HttpServletRequest): String
     fun validateRefreshToken(token: String): String
     fun generateNewAccessToken(username: String): String
     fun generateNewRefreshToken(username: String): String

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/service/TokenRefreshServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/service/TokenRefreshServiceImpl.kt
@@ -15,16 +15,9 @@ class TokenRefreshServiceImpl(
     private val jwtUtils: JwtUtils,
     private val jwtProperties: JWTProperties
 ) : TokenRefreshService {
-    override fun extractRefreshToken(request: HttpServletRequest): String {
-        println("request.cookies == null : ${request.cookies == null}")
-        for (h in request.headerNames) {
-            println("header : $h")
-        }
+    override fun extractRefreshTokenFromCookie(request: HttpServletRequest): String {
         val cookies = request.cookies
             ?: throw BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND)
-        for (c in request.cookies) {
-            println("cookie.name: ${c.name} / cookie.value: ${c.value}")
-        }
         val refreshTokenCookie = cookies.firstOrNull { it.name == "refresh_token" }
             ?: throw BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND)
         return refreshTokenCookie.value

--- a/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/RefreshToken.http
+++ b/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/RefreshToken.http
@@ -1,0 +1,7 @@
+###
+GET http://localhost:8080/api/v1/auth/refresh_token
+Content-Type: application/json
+
+{
+  "refreshToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY2OTkwNDh9.GuY1Fpu-_dalV6gdYH-LeSyg3IKx3pQVfnS6GQTtbWM"
+}


### PR DESCRIPTION
## 🔑 Key Changes
- HttpOnly 쿠키가 전송되지 않는 에러 때문에 토큰 재발급과 관련된 요청 ( `/api/v1/auth/refresh_token`, `/api/v1/auth/facebook_signup` )에서 리프레시 토큰을 request body로 수신하도록 수정
## :computer: Test Result
- `RefreshToken.http`