### PR TITLE
Feat/비밀번호 재설정 API

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/global/error_handling/ErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/global/error_handling/ErrorCode.kt
@@ -26,6 +26,8 @@ enum class ErrorCode(
     ALREADY_OPEN(403, "U004", "이미 공개 계정입니다."),
     USERNAME_ALREADY_EXIST(409, "U005", "Username already exists."),
     LINK_NOT_FOUND(404, "U006", "Link not found."),
+    NEW_PASSWORD_EQUAL(400, "U007", "기존 패스워드와 새로운 패스워드가 동일합니다."),
+    INVALID_OLD_PASSWORD(403, "U008", "기존 패스워드가 올바르지 않습니다."),
 
     // Controller-level Authentication Exceptions
     REFRESH_TOKEN_NOT_FOUND(400, "A001", "refresh token이 쿠키에 존재하지 않습니다."),

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/controller/PostController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/controller/PostController.kt
@@ -46,10 +46,11 @@ class PostController(
         @RequestPart("content") content: String,
         @RequestPart("hideComments") hideComments: String = "false",
         @RequestPart("hideLikes") hideLikes: String = "false",
-        @RequestPart("category") category: PostCategory,
+        @RequestPart("category") category: String,
         @RequestPart("files") files: List<MultipartFile>,
     ): ResponseEntity<PostBrief> {
         val imageUrls = postImageService.uploadImages(files)
+        val category = PostCategory.valueOf(category)
 
         // 게시물 생성 로직 처리
         val post =

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/controller/UserPasswordController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/controller/UserPasswordController.kt
@@ -1,0 +1,29 @@
+package com.wafflestudio.toyproject.waffle5gramserver.user.controller
+
+import com.wafflestudio.toyproject.waffle5gramserver.user.dto.PasswordChangeRequestDto
+import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
+import com.wafflestudio.toyproject.waffle5gramserver.user.service.UserPasswordService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class UserPasswordController(
+    private val userPasswordService: UserPasswordService
+) {
+    @PutMapping("/api/v1/account/password")
+    fun updatePassword(
+        @RequestBody passwordChangeRequestDto: PasswordChangeRequestDto,
+        @AuthenticationPrincipal user: InstagramUser
+    ): ResponseEntity<Any?> {
+        userPasswordService.changePassword(
+            rawOldPassword = passwordChangeRequestDto.oldPassword,
+            rawNewPassword = passwordChangeRequestDto.newPassword,
+            user = user
+        )
+        return ResponseEntity.status(HttpStatus.OK).build()
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/dto/PasswordChangeRequestDto.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/dto/PasswordChangeRequestDto.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.toyproject.waffle5gramserver.user.dto
+
+data class PasswordChangeRequestDto(
+    val oldPassword: String,
+    val newPassword: String,
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/service/UserPasswordService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/service/UserPasswordService.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.toyproject.waffle5gramserver.user.service
+
+interface UserPasswordService {
+    fun changePassword(rawOldPassword: String, rawNewPassword: String, user: InstagramUser)
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/service/UserPasswordServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/service/UserPasswordServiceImpl.kt
@@ -1,0 +1,35 @@
+package com.wafflestudio.toyproject.waffle5gramserver.user.service
+
+import com.wafflestudio.toyproject.waffle5gramserver.global.error_handling.BusinessException
+import com.wafflestudio.toyproject.waffle5gramserver.global.error_handling.ErrorCode
+import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserRepository
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import kotlin.jvm.optionals.getOrNull
+
+@Service
+class UserPasswordServiceImpl(
+    private val passwordEncoder: PasswordEncoder,
+    private val userRepository: UserRepository,
+    private val txManager: PlatformTransactionManager,
+) : UserPasswordService {
+
+    private val txTemplate = TransactionTemplate(txManager)
+
+    override fun changePassword(rawOldPassword: String, rawNewPassword: String, user: InstagramUser) {
+        if (rawOldPassword == rawNewPassword) {
+            throw BusinessException(ErrorCode.NEW_PASSWORD_EQUAL)
+        }
+        val newPassword = passwordEncoder.encode(rawNewPassword)
+        txTemplate.execute {
+            val userEntity = userRepository.findById(user.id).getOrNull()
+                ?: throw BusinessException(ErrorCode.USER_NOT_FOUND)
+            if (!passwordEncoder.matches(rawOldPassword, userEntity.password)) {
+                throw BusinessException(ErrorCode.INVALID_OLD_PASSWORD)
+            }
+            userEntity.password = newPassword
+        }
+    }
+}

--- a/src/main/resources/application-dev-secure.yaml
+++ b/src/main/resources/application-dev-secure.yaml
@@ -14,7 +14,7 @@ spring:
     password: 1234
   jpa:
     defer-datasource-initialization: true
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         default_batch_fetch_size: 50

--- a/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/UserPassword.http
+++ b/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/user/UserPassword.http
@@ -1,0 +1,38 @@
+###
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "username": "user-0",
+  "password": "password-0"
+}
+
+### 올바른 비밀번호 변경 요청
+PUT http://localhost:8080/api/v1/account/password
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3MDg4NTN9.PrWRaMnOGLJSdkC6nfT1XXSfMyznHHA1oeCeaxd9ItI
+
+{
+  "oldPassword": "password-0",
+  "newPassword": "password-0000"
+}
+
+### 기존 비밀번호와 새로운 비밀번호가 동일함
+PUT http://localhost:8080/api/v1/account/password
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3MDg4NTN9.PrWRaMnOGLJSdkC6nfT1XXSfMyznHHA1oeCeaxd9ItI
+
+{
+  "oldPassword": "password-0000",
+  "newPassword": "password-0000"
+}
+
+### 기존 패스워드가 올바르지 않음
+PUT http://localhost:8080/api/v1/account/password
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3MDg4NTN9.PrWRaMnOGLJSdkC6nfT1XXSfMyznHHA1oeCeaxd9ItI
+
+{
+  "oldPassword": "pass",
+  "newPassword": "password-1010"
+}


### PR DESCRIPTION
## 🔑 Key Changes
- `PUT /api/v1/account/password` 구현을 위한 `UserPasswordController`, `UserPasswordService`
- 알게 된 사실: spring security의 `DelegatingPasswordEncoder` (현재 기준으로 `BCryptPasswordEncoder`)는 보안을 위해 패스워드를 인코딩할 때마다 다른 문자열로 인코딩한다. 그래서 똑같은지 보려면 matches 함수를 사용해야 한다.
## :computer: Test Result (기능 구현인 경우)
- `UserPassword.http` 참고