### PR TITLE
Feat/탐색 탭 프리뷰 & 피드 API 구현

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/ProdCommandLineRunner.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/ProdCommandLineRunner.kt
@@ -9,6 +9,7 @@ import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostMediaEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostRepository
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostLikeService
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostSaveService
 import com.wafflestudio.toyproject.waffle5gramserver.user.repository.ContactEntity
 import com.wafflestudio.toyproject.waffle5gramserver.user.repository.ContactType
 import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserEntity
@@ -32,6 +33,7 @@ class ProdCommandLineRunner(
     private val postLikeService: PostLikeService,
     private val commentService: CommentService,
     private val followRepository: FollowRepository,
+    private val postSaveService: PostSaveService,
 ) : CommandLineRunner {
 
     private val txTemplate = TransactionTemplate(txManager)
@@ -215,6 +217,10 @@ class ProdCommandLineRunner(
                     postLikeService.create(postIdList[i], userIdList[j])
                     commentService.create(postIdList[i], "Good place", userIdList[j])
                 }
+            }
+            for (i in 1 until 7 step 2) {
+                postLikeService.create(i.toLong(), userIdList[0])
+                postSaveService.create(i.toLong() + 1, userIdList[0])
             }
         }
     }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/controller/ExploreController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/controller/ExploreController.kt
@@ -19,22 +19,21 @@ class ExploreController(
         exploreQueryDto: ExploreQueryDto,
         @AuthenticationPrincipal user: InstagramUser
     ): ResponseEntity<ExploreResponseDto> {
-        val slicedPosts = exploreService.getSlicedPosts(
+        val slicedExplorePreview = exploreService.getRandomSimpleSlicedPosts(
             user = user,
             page = exploreQueryDto.page,
             size = exploreQueryDto.size,
-            sortType = exploreQueryDto.sort,
             category = exploreQueryDto.category,
         )
         return ResponseEntity.ok(
             ExploreResponseDto(
-                postMediasBriefList = slicedPosts.content.toList(),
+                previews = slicedExplorePreview.content,
                 pageInfo = PageInfo(
-                    page = slicedPosts.number,
-                    size = slicedPosts.size,
-                    offset = slicedPosts.pageable.offset,
-                    hasNext = slicedPosts.hasNext(),
-                    elements = slicedPosts.numberOfElements
+                    page = slicedExplorePreview.number,
+                    size = slicedExplorePreview.size,
+                    offset = slicedExplorePreview.pageable.offset,
+                    hasNext = slicedExplorePreview.hasNext(),
+                    elements = slicedExplorePreview.numberOfElements
                 )
             )
         )

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/controller/ExploreController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/controller/ExploreController.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.toyproject.waffle5gramserver.explore.controller
 
+import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExploreFeedResponseDto
 import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExploreQueryDto
 import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExploreResponseDto
 import com.wafflestudio.toyproject.waffle5gramserver.explore.service.ExploreService
@@ -8,6 +9,8 @@ import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -34,6 +37,32 @@ class ExploreController(
                     offset = slicedExplorePreview.pageable.offset,
                     hasNext = slicedExplorePreview.hasNext(),
                     elements = slicedExplorePreview.numberOfElements
+                )
+            )
+        )
+    }
+
+    @GetMapping("/api/v1/explore/{postId}")
+    fun getFeeds(
+        @PathVariable postId: String,
+        @RequestParam(name = "page", required = false) page: Int = 0,
+        @RequestParam(name = "size", required = false) size: Int = 6,
+        @AuthenticationPrincipal user: InstagramUser
+    ): ResponseEntity<ExploreFeedResponseDto> {
+        val slicedPostDetails = exploreService.getRandomDetailedSlicedPosts(
+            user = user,
+            page = page,
+            size = size
+        )
+        return ResponseEntity.ok(
+            ExploreFeedResponseDto(
+                posts = slicedPostDetails.content.shuffled(),
+                pageInfo = PageInfo(
+                    page = slicedPostDetails.number,
+                    size = slicedPostDetails.size,
+                    offset = slicedPostDetails.pageable.offset,
+                    hasNext = slicedPostDetails.hasNext(),
+                    elements = slicedPostDetails.numberOfElements
                 )
             )
         )

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/dto/ExploreFeedResponseDto.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/dto/ExploreFeedResponseDto.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.toyproject.waffle5gramserver.explore.dto
+
+import com.wafflestudio.toyproject.waffle5gramserver.feed.controller.PageInfo
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
+
+data class ExploreFeedResponseDto(
+    val posts: List<PostDetail>,
+    val pageInfo: PageInfo
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/dto/ExplorePreview.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/dto/ExplorePreview.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.toyproject.waffle5gramserver.explore.dto
+
+data class ExplorePreview(
+    val postId: Long,
+    val thumbnailUrl: String?,
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/dto/ExploreQueryDto.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/dto/ExploreQueryDto.kt
@@ -5,6 +5,5 @@ import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostCategor
 data class ExploreQueryDto(
     val page: Int = 0,
     val size: Int = 6,
-    val sort: ExplorePostSortType,
     val category: PostCategory? = null,
 )

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/dto/ExploreResponseDto.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/dto/ExploreResponseDto.kt
@@ -1,9 +1,8 @@
 package com.wafflestudio.toyproject.waffle5gramserver.explore.dto
 
 import com.wafflestudio.toyproject.waffle5gramserver.feed.controller.PageInfo
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostMediasBrief
 
 data class ExploreResponseDto(
-    val postMediasBriefList: List<PostMediasBrief>,
+    val previews: List<ExplorePreview>,
     val pageInfo: PageInfo
 )

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.toyproject.waffle5gramserver.explore.service
 
 import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExplorePostSortType
+import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExplorePreview
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostCategory
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostMediasBrief
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
@@ -8,4 +9,6 @@ import org.springframework.data.domain.Slice
 
 interface ExploreService {
     fun getSlicedPosts(user: InstagramUser, page: Int, size: Int, sortType: ExplorePostSortType, category: PostCategory?): Slice<PostMediasBrief>
+
+    fun getRandomSimpleSlicedPosts(user: InstagramUser, page: Int, size: Int, category: PostCategory?): Slice<ExplorePreview>
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreService.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.toyproject.waffle5gramserver.explore.service
 import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExplorePostSortType
 import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExplorePreview
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostCategory
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostMediasBrief
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
 import org.springframework.data.domain.Slice
@@ -11,4 +12,6 @@ interface ExploreService {
     fun getSlicedPosts(user: InstagramUser, page: Int, size: Int, sortType: ExplorePostSortType, category: PostCategory?): Slice<PostMediasBrief>
 
     fun getRandomSimpleSlicedPosts(user: InstagramUser, page: Int, size: Int, category: PostCategory?): Slice<ExplorePreview>
+
+    fun getRandomDetailedSlicedPosts(user: InstagramUser, page: Int, size: Int): Slice<PostDetail>
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreServiceImpl.kt
@@ -4,15 +4,19 @@ import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExplorePostSort
 import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExplorePreview
 import com.wafflestudio.toyproject.waffle5gramserver.post.mapper.PostMapper
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostCategory
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostRepository
+import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostMediasBrief
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostPaginationService
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 
 @Service
 class ExploreServiceImpl(
     private val postPaginationService: PostPaginationService,
+    private val postRepository: PostRepository
 ) : ExploreService {
 
     override fun getSlicedPosts(
@@ -53,6 +57,19 @@ class ExploreServiceImpl(
                 postId = it.id,
                 thumbnailUrl = it.medias.getOrNull(0)?.mediaUrl
             )
+        }
+    }
+
+    override fun getRandomDetailedSlicedPosts(
+        user: InstagramUser,
+        page: Int,
+        size: Int,
+    ): Slice<PostDetail> {
+        return postRepository.findSlicedPostDetails(
+            pageable = PageRequest.of(page, size),
+            currentUserId = user.id
+        ).map {
+            PostMapper.toPostMediaDetail(it)
         }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.toyproject.waffle5gramserver.explore.service
 
-import com.wafflestudio.toyproject.waffle5gramserver.comment.repository.CommentRepository
 import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExplorePostSortType
+import com.wafflestudio.toyproject.waffle5gramserver.explore.dto.ExplorePreview
 import com.wafflestudio.toyproject.waffle5gramserver.post.mapper.PostMapper
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostCategory
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostMediasBrief
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service
 @Service
 class ExploreServiceImpl(
     private val postPaginationService: PostPaginationService,
-    private val commentRepository: CommentRepository,
 ) : ExploreService {
 
     override fun getSlicedPosts(
@@ -40,6 +39,20 @@ class ExploreServiceImpl(
                 postPaginationService.getMostCommentedPosts(user, page, size, category).map {
                     PostMapper.toPostMediasBrief(it.getPostEntity(), it.getCommentCount())
                 }
+        }
+    }
+
+    override fun getRandomSimpleSlicedPosts(
+        user: InstagramUser,
+        page: Int,
+        size: Int,
+        category: PostCategory?
+    ): Slice<ExplorePreview> {
+        return postPaginationService.getRandomPosts(user, size, category).map {
+            ExplorePreview(
+                postId = it.id,
+                thumbnailUrl = it.medias.getOrNull(0)?.mediaUrl
+            )
         }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/mapper/PostMapper.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.mapper
 
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostDetailQueryResult
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostMediaEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostAuthor
@@ -61,6 +62,29 @@ class PostMapper {
                 category = entity.category,
                 likeCount = entity.likeCount,
                 commentCount = commentCount
+            )
+        }
+
+        fun toPostMediaDetail(postDetailQueryResult: PostDetailQueryResult): PostDetail {
+            val post = postDetailQueryResult.getPostEntity()
+            val profileImageUrl = postDetailQueryResult.getProfileImageUrl()
+                ?: "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Default_pfp.svg/680px-Default_pfp.svg.png?20220226140232"
+            return PostDetail(
+                id = post.id,
+                author = PostAuthor(
+                    id = postDetailQueryResult.getUserId(),
+                    username = postDetailQueryResult.getUsername(),
+                    profileImageUrl = profileImageUrl
+                ),
+                content = post.content,
+                media = post.medias.map { toPostMediaDTO(it) },
+                liked = postDetailQueryResult.getPostLikeCount() >= 1,
+                likeCount = post.likeCount,
+                saved = postDetailQueryResult.getPostSaveCount() >= 1,
+                commentCount = postDetailQueryResult.getCommentCount().toInt(),
+                hideLike = !post.likeCountDisplayed,
+                createdAt = post.createdAt,
+                category = post.category
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostDetailQueryResult.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostDetailQueryResult.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.toyproject.waffle5gramserver.post.repository
+
+interface PostDetailQueryResult {
+    fun getPostEntity(): PostEntity
+    fun getUserId(): Long
+    fun getUsername(): String
+    fun getProfileImageUrl(): String?
+    fun getPostLikeCount(): Int
+    fun getPostSaveCount(): Int
+    fun getCommentCount(): Long
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostEntityWithCommentCount.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostEntityWithCommentCount.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.toyproject.waffle5gramserver.post.repository
+
+interface PostEntityWithCommentCount {
+    fun getPostEntity(): PostEntity
+    fun getCommentCount(): Long
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
@@ -98,4 +98,21 @@ interface PostRepository : JpaRepository<PostEntity, Long> {
         """
     )
     fun findSliceCommentDisplayedOrderByCommentCountDescByCategory(pageable: Pageable, category: PostCategory): Slice<PostEntityWithCommentCount>
+
+    @Query(
+        """
+            SELECT p AS postEntity, 
+            p.user.id AS userId, 
+            p.user.username AS username, 
+            p.user.profileImageUrl AS profileImageUrl,
+            (SELECT COUNT(pl) FROM post_likes pl WHERE pl.userId = :currentUserId AND pl.postId = p.id) AS postLikeCount,
+            (SELECT COUNT(ps) FROM post_saves ps WHERE ps.userId = :currentUserId AND ps.postId = p.id) AS postSaveCount,
+            COUNT(c.id) AS commentCount
+            FROM posts p
+            INNER JOIN comments c
+            WHERE p.user.isPrivate = false
+            GROUP BY p
+        """
+    )
+    fun findSlicedPostDetails(pageable: Pageable, currentUserId: Long): Slice<PostDetailQueryResult>
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.repository
 
-import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostEntityWithCommentCount
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostEntityWithCommentCount.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostEntityWithCommentCount.kt
@@ -1,8 +1,0 @@
-package com.wafflestudio.toyproject.waffle5gramserver.post.service
-
-import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
-
-interface PostEntityWithCommentCount {
-    fun getPostEntity(): PostEntity
-    fun getCommentCount(): Long
-}

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostPaginationService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostPaginationService.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.toyproject.waffle5gramserver.post.service
 
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostCategory
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntityWithCommentCount
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
 import org.springframework.data.domain.Slice
 

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostPaginationServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostPaginationServiceImpl.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.toyproject.waffle5gramserver.post.service
 
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostCategory
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntityWithCommentCount
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostRepository
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
 import org.springframework.data.domain.PageRequest

--- a/src/main/resources/application-dev-secure.yaml
+++ b/src/main/resources/application-dev-secure.yaml
@@ -14,7 +14,7 @@ spring:
     password: 1234
   jpa:
     defer-datasource-initialization: true
-    show-sql: false
+    show-sql: true
     properties:
       hibernate:
         default_batch_fetch_size: 50

--- a/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/Explore.http
+++ b/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/Explore.http
@@ -7,10 +7,14 @@ Content-Type: application/json
   "password": "password-0"
 }
 
-### 랜덤 (카테고리 미지정)
+### 탐색 탭 프리뷰 조회 (카테고리 미지정)
 GET http://localhost:8080/api/v1/explore?page=0&size=8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3ODQzNzZ9.FPXBNJLtqT0Slcyjh732fZQANGVDk6EYqUv9iXcJNeQ
 
-### 랜덤 (카테고리 지정)
+### 탐색 탭 프리뷰 조회 (카테고리 지정)
 GET http://localhost:8080/api/v1/explore?page=0&size=8&category=TRAVEL
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3ODQzNzZ9.FPXBNJLtqT0Slcyjh732fZQANGVDk6EYqUv9iXcJNeQ
+
+### 탐색 탭 피드 조회
+GET http://localhost:8080/api/v1/explore/1?page=0&size=12
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3ODQzNzZ9.FPXBNJLtqT0Slcyjh732fZQANGVDk6EYqUv9iXcJNeQ

--- a/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/Explore.http
+++ b/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/Explore.http
@@ -7,22 +7,10 @@ Content-Type: application/json
   "password": "password-0"
 }
 
-### 최신순
-GET http://localhost:8080/api/v1/explore?page=0&size=5&sort=LATEST&category=TRAVEL
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY1MzI3NDN9.fi7Qcc4SGxXMkc7v9GcgD9DQxaeGlksrINXCjzQPMAk
-
-### 좋아요 많은 순
-GET http://localhost:8080/api/v1/explore?page=0&size=7&sort=MOST_LIKED&category=TRAVEL
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY1MzQwNzB9.jhpdLIsgMeugP0U9MeBh5ljMiljL38DlUDG_R9nfI9k
-
-### 댓글 많은 순
-GET http://localhost:8080/api/v1/explore?page=0&size=8&sort=MOST_COMMENTED&category=TRAVEL
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY2MTU5MDZ9.M28ZgY4Y9oajVWxOfd_nQO6WcYWjfGc9ss7g9FXGaqo
-
 ### 랜덤 (카테고리 미지정)
-GET http://localhost:8080/api/v1/explore?page=0&size=8&sort=RANDOM
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY1NDMwNTh9.HB1QPnKEhAtDrtXChtEIYeYhiQVEFmjMWNS-GYwOqqo
+GET http://localhost:8080/api/v1/explore?page=0&size=8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3ODQzNzZ9.FPXBNJLtqT0Slcyjh732fZQANGVDk6EYqUv9iXcJNeQ
 
 ### 랜덤 (카테고리 지정)
-GET http://localhost:8080/api/v1/explore?page=0&size=8&sort=RANDOM&category=TRAVEL
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY1Mzc4NzV9.MQ0ErwrImc-tZh5hiAiSND-v_dUxxv6u3Fe5pYx2VzA
+GET http://localhost:8080/api/v1/explore?page=0&size=8&category=TRAVEL
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3ODQzNzZ9.FPXBNJLtqT0Slcyjh732fZQANGVDk6EYqUv9iXcJNeQ

--- a/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/PostDetailQueryResultTest.kt
+++ b/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/PostDetailQueryResultTest.kt
@@ -1,0 +1,35 @@
+package com.wafflestudio.toyproject.waffle5gramserver.explore
+
+import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+// import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+class PostDetailQueryResultTest @Autowired constructor(
+    private val postRepository: PostRepository
+) {
+    @Test
+    fun getPostDetailQueryResult() {
+        // val x = postRepository.findSlicedPostDetails(
+        //     PageRequest.of(0, 18),
+        //     currentUserId = 1
+        // )
+        // val y = x.content
+        // for (r in y) {
+        //     val p = r.getPostEntity()
+        //     println(p.id)
+        //     println(p.content)
+        //     println(p.category)
+        //     println(r.getUserId())
+        //     println(r.getUsername())
+        //     println(r.getProfileImageUrl())
+        //     println(r.getPostLikeCount())
+        //     println(r.getPostSaveCount())
+        //     println(r.getCommentCount())
+        // }
+    }
+}


### PR DESCRIPTION
## 🔑 Key Changes
- 탐색 탭 프리뷰 (`/api/v1/explore`) 수정 및 탐색 탭 피드 (`/api/v1/explore/{postId}`) 수정
- 기존에 구현한 함수들 바탕으로 프리뷰 조회를 위한 `ExploreService.getRandomSimpleSlicedPosts`와 피드 조회를 위한 `ExploreService.getRandomDetailedSlicedPosts`를 작성하였습니다.
- 피드 조회를 위해 `PostDetail`의 리스트를 리턴해야 하는데, `PostLikeRepository`, `PostSaveRepository`, `CommentRepository`를 mapper나 service 내에서 조회할 경우 N+1 문제가 발생할 것으로 예상하였습니다. 따라서 `PostDetail`에 필요한 정보를 한번에 쿼리할 수 있도록 `PostRepository.findSlicedPostDetails`와 `PostDetailQueryResult`를 작성하였습니다. 첨부한 스크린샷에 나오듯이 show-sql로 N+1 문제 방지를 확인하였습니다.
## :computer: Test Result (기능 구현인 경우)
- `ExploreApi.http`
## ScreenShot
![스크린샷 2024-02-01 오후 4 06 50](https://github.com/wafflestudio21-5/team5-server/assets/87258768/ea6989d6-0963-48b2-b3d3-755a13d91d4c)
