### PR TITLE
Fix / 탐색 탭 피드 조회 시 page=1인 요청의 첫번째 게시물은 postId가 되도록 고정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/service/TokenRefreshServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/auth/service/TokenRefreshServiceImpl.kt
@@ -54,7 +54,6 @@ class TokenRefreshServiceImpl(
     ) {
         val refreshTokenCookie = Cookie("refresh_token", token).apply {
             path = "/"
-            domain = "waffle5gram.com"
             isHttpOnly = false
             secure = jwtProperties.refreshTokenCookieSecure
             maxAge = jwtProperties.ttlMinutesRefreshToken.toInt() * 60 * 1800 // minutes to seconds

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/controller/ExploreController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/controller/ExploreController.kt
@@ -59,8 +59,7 @@ class ExploreController(
                         )
                     )
                 )
-            }
-            else {
+            } else {
                 val randomPostDetails = exploreService.getRandomDetailedSlicedPosts(
                     user = user,
                     page = page,
@@ -100,7 +99,7 @@ class ExploreController(
         )
     }
 
-    private fun<T> getDefaultPageInfo(slice: Slice<T>): PageInfo {
+    private fun <T> getDefaultPageInfo(slice: Slice<T>): PageInfo {
         return PageInfo(
             page = slice.number + 1,
             size = slice.size,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/controller/ExploreController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/controller/ExploreController.kt
@@ -45,7 +45,7 @@ class ExploreController(
     @GetMapping("/api/v1/explore/{postId}")
     fun getFeeds(
         @PathVariable postId: String,
-        @RequestParam(name = "page", required = false) page: Int = 0,
+        @RequestParam(name = "page", required = false) page: Int = 1,
         @RequestParam(name = "size", required = false) size: Int = 6,
         @AuthenticationPrincipal user: InstagramUser
     ): ResponseEntity<ExploreFeedResponseDto> {

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreService.kt
@@ -14,4 +14,6 @@ interface ExploreService {
     fun getRandomSimpleSlicedPosts(user: InstagramUser, page: Int, size: Int, category: PostCategory?): Slice<ExplorePreview>
 
     fun getRandomDetailedSlicedPosts(user: InstagramUser, page: Int, size: Int): Slice<PostDetail>
+
+    fun getPostById(user: InstagramUser, postId: Long): PostDetail
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreService.kt
@@ -15,5 +15,5 @@ interface ExploreService {
 
     fun getRandomDetailedSlicedPosts(user: InstagramUser, page: Int, size: Int): Slice<PostDetail>
 
-    fun getPostById(user: InstagramUser, postId: Long): PostDetail
+    fun getOnePostById(user: InstagramUser, postId: Long): Slice<PostDetail>
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreServiceImpl.kt
@@ -63,14 +63,20 @@ class ExploreServiceImpl(
         size: Int,
     ): Slice<PostDetail> {
         return postRepository.findSlicedPostDetails(
-            pageable = PageRequest.of(page, size),
+            pageable = postPaginationService.getRandomPageable(size),
             currentUserId = user.id
         ).map {
             PostMapper.toPostMediaDetail(it)
         }
     }
 
-    override fun getPostById(user: InstagramUser, postId: Long): PostDetail {
-        TODO("Not yet implemented")
+    override fun getOnePostById(user: InstagramUser, postId: Long): Slice<PostDetail> {
+        return postRepository.findSlicedPostDetailsByPostId(
+            pageable = PageRequest.of(0, 1),
+            currentUserId = user.id,
+            postId = postId
+        ).map {
+            PostMapper.toPostMediaDetail(it)
+        }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/service/ExploreServiceImpl.kt
@@ -69,4 +69,8 @@ class ExploreServiceImpl(
             PostMapper.toPostMediaDetail(it)
         }
     }
+
+    override fun getPostById(user: InstagramUser, postId: Long): PostDetail {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/SavedFeedController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/SavedFeedController.kt
@@ -1,10 +1,9 @@
 package com.wafflestudio.toyproject.waffle5gramserver.feed.controller
 
+import com.wafflestudio.toyproject.waffle5gramserver.feed.service.PostPreview
 import com.wafflestudio.toyproject.waffle5gramserver.feed.service.SavedFeedService
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
-import org.springframework.data.domain.Pageable
-import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,29 +18,15 @@ class SavedFeedController(
     @GetMapping("/preview")
     fun getSavedFeedPreview(
         @AuthenticationPrincipal authuser: InstagramUser,
-        @PageableDefault(size = 12) pageable: Pageable,
-    ): ResponseEntity<Any> {
-        val postPreviews = savedFeedService.getSavedFeedPreview(authuser.id, pageable)
-        val feedPreviewResponse =
-            FeedPreviewResponse(
-                posts = postPreviews.content,
-                pageInfo =
-                PageInfo(
-                    page = pageable.pageNumber + 1,
-                    size = pageable.pageSize,
-                    offset = pageable.offset,
-                    hasNext = postPreviews.size == pageable.pageSize,
-                    elements = postPreviews.size,
-                ),
-            )
-        return ResponseEntity.ok(feedPreviewResponse)
+    ): ResponseEntity<List<PostPreview>> {
+        val postPreviews = savedFeedService.getSavedFeedPreview(authuser.id)
+        return ResponseEntity.ok(postPreviews)
     }
 
     // 피드 조회 API
     @GetMapping("")
     fun getSavedFeed(
         @AuthenticationPrincipal authuser: InstagramUser,
-        @PageableDefault(size = 10) pageable: Pageable,
     ): ResponseEntity<List<PostDetail>> {
         val posts = savedFeedService.getSavedFeed(authuser.id)
         return ResponseEntity.ok(posts)

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/UserFeedController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/controller/UserFeedController.kt
@@ -1,11 +1,9 @@
 package com.wafflestudio.toyproject.waffle5gramserver.feed.controller
 
+import com.wafflestudio.toyproject.waffle5gramserver.feed.service.PostPreview
 import com.wafflestudio.toyproject.waffle5gramserver.feed.service.UserFeedService
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort
-import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -23,23 +21,9 @@ class UserFeedController(
     fun getUserFeedPreview(
         @AuthenticationPrincipal authuser: InstagramUser,
         @PathVariable username: String,
-        @PageableDefault(size = 12, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
-    ): ResponseEntity<Any> {
-        val postPreviews = userFeedService.getUserFeedPreview(authuser, username, pageable)
-
-        val feedPreviewResponse =
-            FeedPreviewResponse(
-                posts = postPreviews.content,
-                pageInfo =
-                PageInfo(
-                    page = pageable.pageNumber + 1,
-                    size = pageable.pageSize,
-                    offset = pageable.offset,
-                    hasNext = postPreviews.size == pageable.pageSize,
-                    elements = postPreviews.size,
-                ),
-            )
-        return ResponseEntity.ok(feedPreviewResponse)
+    ): ResponseEntity<List<PostPreview>> {
+        val postPreviews = userFeedService.getUserFeedPreview(authuser, username)
+        return ResponseEntity.ok(postPreviews)
     }
 
     // 피드 조회 API

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/SavedFeedService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/SavedFeedService.kt
@@ -1,16 +1,9 @@
 package com.wafflestudio.toyproject.waffle5gramserver.feed.service
 
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 
 interface SavedFeedService {
-    fun getSavedFeedPreview(
-        userId: Long,
-        pageable: Pageable,
-    ): Slice<PostPreview>
+    fun getSavedFeedPreview(userId: Long): List<PostPreview>
 
-    fun getSavedFeed(
-        userId: Long,
-    ): List<PostDetail>
+    fun getSavedFeed(userId: Long): List<PostDetail>
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/SavedFeedServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/SavedFeedServiceImpl.kt
@@ -6,8 +6,6 @@ import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostReposit
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostSaveRepository
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
 import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserRepository
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 
 @Service
@@ -17,15 +15,12 @@ class SavedFeedServiceImpl(
     private val postLikeRepository: PostLikeRepository,
     private val postSaveRepository: PostSaveRepository,
 ) : SavedFeedService {
-    override fun getSavedFeedPreview(
-        userId: Long,
-        pageable: Pageable,
-    ): Slice<PostPreview> {
+    override fun getSavedFeedPreview(userId: Long): List<PostPreview> {
         val user = userRepository.findById(userId).orElseThrow { throw IllegalArgumentException("User not found") }
         // 저장된 게시물을 조회
-        val postSaveEntities = postSaveRepository.findByUserId(user.id, pageable).content
+        val postSaveEntities = postSaveRepository.findByUserId(user.id)
         val postIds = postSaveEntities.map { it.postId }
-        val posts = postRepository.findByIdIn(postIds, pageable)
+        val posts = postRepository.findByIdIn(postIds)
 
         return posts.map { post ->
             PostPreview(

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedService.kt
@@ -2,15 +2,12 @@ package com.wafflestudio.toyproject.waffle5gramserver.feed.service
 
 import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 
 interface UserFeedService {
     fun getUserFeedPreview(
         authuser: InstagramUser,
         username: String,
-        pageable: Pageable,
-    ): Slice<PostPreview>
+    ): List<PostPreview>
 
     fun getUserFeed(
         authuser: InstagramUser,

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedServiceImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/feed/service/UserFeedServiceImpl.kt
@@ -11,8 +11,6 @@ import com.wafflestudio.toyproject.waffle5gramserver.post.service.PostDetail
 import com.wafflestudio.toyproject.waffle5gramserver.user.repository.UserRepository
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
 import jakarta.transaction.Transactional
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 
 @Service
@@ -26,13 +24,12 @@ class UserFeedServiceImpl(
     override fun getUserFeedPreview(
         authuser: InstagramUser,
         username: String,
-        pageable: Pageable,
-    ): Slice<PostPreview> {
+    ): List<PostPreview> {
         val user = userRepository.findByUsername(username).orElseThrow { throw IllegalArgumentException("User not found") }
         if (user.isPrivate && (followRepository.findByFollowerUserIdAndFolloweeUserId(authuser.id, user.id) == null)) {
             throw PrivateException(ErrorCode.USER_PRIVATE_NOT_FOLLOWING)
         }
-        val posts = postRepository.findPostsByUserId(user.id, pageable)
+        val posts = postRepository.findPostsByUserId(user.id)
 
         return posts.map { post ->
             PostPreview(

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
@@ -31,13 +31,27 @@ interface PostRepository : JpaRepository<PostEntity, Long> {
     @Query("SELECT p FROM posts p WHERE p.user.id = :userId")
     fun findAllByUserId(userId: Long): List<PostEntity>
 
-    @Query("SELECT p FROM posts p WHERE p.user.isPrivate = false")
-    fun findSlice(pageable: Pageable): Slice<PostEntity>
+    @Query(
+        """
+        SELECT p FROM posts p 
+        WHERE p.user.isPrivate = false 
+        AND p.user.id <> :currentUserId
+        """
+    )
+    fun findSlice(pageable: Pageable, currentUserId: Long): Slice<PostEntity>
 
-    @Query("SELECT p FROM posts p WHERE p.user.isPrivate = false AND p.category = :category")
+    @Query(
+        """
+        SELECT p FROM posts p 
+        WHERE p.user.isPrivate = false 
+        AND p.user.id <> :currentUserId
+        AND p.category = :category
+        """
+    )
     fun findSliceByCategory(
         pageable: Pageable,
         category: PostCategory,
+        currentUserId: Long,
     ): Slice<PostEntity>
 
     @Query(
@@ -99,6 +113,7 @@ interface PostRepository : JpaRepository<PostEntity, Long> {
             FROM posts p
             INNER JOIN comments c
             WHERE p.user.isPrivate = false
+            AND p.user.id <> :currentUserId
             GROUP BY p
         """
     )
@@ -110,4 +125,27 @@ interface PostRepository : JpaRepository<PostEntity, Long> {
     ): Slice<PostEntity>
 
     fun findByIdIn(postIds: List<Long>): List<PostEntity>
+
+    @Query(
+        """
+            SELECT p AS postEntity, 
+            p.user.id AS userId, 
+            p.user.username AS username, 
+            p.user.profileImageUrl AS profileImageUrl,
+            (SELECT COUNT(pl) FROM post_likes pl WHERE pl.userId = :currentUserId AND pl.postId = p.id) AS postLikeCount,
+            (SELECT COUNT(ps) FROM post_saves ps WHERE ps.userId = :currentUserId AND ps.postId = p.id) AS postSaveCount,
+            COUNT(c.id) AS commentCount
+            FROM posts p
+            INNER JOIN comments c
+            WHERE p.user.isPrivate = false
+            AND p.user.id <> :currentUserId
+            AND p.id = :postId
+            GROUP BY p
+        """
+    )
+    fun findSlicedPostDetailsByPostId(
+        pageable: Pageable,
+        currentUserId: Long,
+        postId: Long
+    ): Slice<PostDetailQueryResult>
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostRepository.kt
@@ -6,27 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface PostRepository : JpaRepository<PostEntity, Long> {
-    // 사용자 ID와 커서 기반으로 게시물 목록 조회
-    @Query("SELECT p FROM posts p WHERE p.user.id = :userId AND p.id < :cursor ORDER BY p.id DESC")
-    fun findPostsByUserIdAndCursor(
-        userId: Long,
-        cursor: Long,
-        pageable: Pageable,
-    ): List<PostEntity>
-
-    fun findPostsByUserId(
-        userId: Long,
-        pageable: Pageable,
-    ): Slice<PostEntity>
-
     fun findPostsByUserId(userId: Long): List<PostEntity>
-
-    // 사용자 ID로 최신 게시물 목록 조회 (초기 로드용)
-    @Query("SELECT p FROM posts p WHERE p.user.id = :userId ORDER BY p.id DESC")
-    fun findLatestPostsByUserId(
-        userId: Long,
-        pageable: Pageable,
-    ): List<PostEntity>
 
     @Query("SELECT p FROM posts p WHERE p.user.id = :userId")
     fun findAllByUserId(userId: Long): List<PostEntity>
@@ -118,11 +98,6 @@ interface PostRepository : JpaRepository<PostEntity, Long> {
         """
     )
     fun findSlicedPostDetails(pageable: Pageable, currentUserId: Long): Slice<PostDetailQueryResult>
-
-    fun findByIdIn(
-        postIds: List<Long>,
-        pageable: Pageable,
-    ): Slice<PostEntity>
 
     fun findByIdIn(postIds: List<Long>): List<PostEntity>
 

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/repository/PostSaveRepository.kt
@@ -1,7 +1,5 @@
 package com.wafflestudio.toyproject.waffle5gramserver.post.repository
 
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PostSaveRepository : JpaRepository<PostSaveEntity, Long> {
@@ -16,11 +14,6 @@ interface PostSaveRepository : JpaRepository<PostSaveEntity, Long> {
         postId: Long,
         userId: Long,
     ): PostSaveEntity?
-
-    fun findByUserId(
-        userId: Long,
-        pageable: Pageable,
-    ): Slice<PostSaveEntity>
 
     fun findByUserId(userId: Long): List<PostSaveEntity>
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostPaginationService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/waffle5gramserver/post/service/PostPaginationService.kt
@@ -4,6 +4,7 @@ import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostCategor
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntity
 import com.wafflestudio.toyproject.waffle5gramserver.post.repository.PostEntityWithCommentCount
 import com.wafflestudio.toyproject.waffle5gramserver.user.service.InstagramUser
+import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
 interface PostPaginationService {
@@ -11,4 +12,6 @@ interface PostPaginationService {
     fun getLatestPosts(user: InstagramUser, page: Int, size: Int, category: PostCategory?): Slice<PostEntity>
     fun getMostLikedPosts(user: InstagramUser, page: Int, size: Int, category: PostCategory?): Slice<PostEntity>
     fun getMostCommentedPosts(user: InstagramUser, page: Int, size: Int, category: PostCategory?): Slice<PostEntityWithCommentCount>
+
+    fun getRandomPageable(size: Int): Pageable
 }

--- a/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/Explore.http
+++ b/src/test/kotlin/com/wafflestudio/toyproject/waffle5gramserver/explore/Explore.http
@@ -15,6 +15,10 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3O
 GET http://localhost:8080/api/v1/explore?page=0&size=8&category=TRAVEL
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3ODQzNzZ9.FPXBNJLtqT0Slcyjh732fZQANGVDk6EYqUv9iXcJNeQ
 
-### 탐색 탭 피드 조회
-GET http://localhost:8080/api/v1/explore/1?page=0&size=12
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY3ODQzNzZ9.FPXBNJLtqT0Slcyjh732fZQANGVDk6EYqUv9iXcJNeQ
+### 탐색 탭 피드 조회 (1번 페이지)
+GET http://localhost:8080/api/v1/explore/3?page=1&size=12
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY4MTg4MTF9.jSTaujPug3Q3UoV4W-SZqXSE4OEgi7H0OZz69GbkUGw
+
+### 탐색 탭 피드 조회 (2 이상의 페이지 번호)
+GET http://localhost:8080/api/v1/explore/1?page=2&size=4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTAiLCJleHAiOjE3MDY4MTg4MTF9.jSTaujPug3Q3UoV4W-SZqXSE4OEgi7H0OZz69GbkUGw


### PR DESCRIPTION
## 🔑 Key Changes
- /api/v1/explore/{postId}의 page=1인 요청의 첫번째 게시물은 postId가 되도록 고정